### PR TITLE
chore: update the command for running local rollup to dev rollup

### DIFF
--- a/docs/dev-cluster/2-deploy-a-local-rollup.md
+++ b/docs/dev-cluster/2-deploy-a-local-rollup.md
@@ -25,7 +25,7 @@ in the `config.rollup` definition.
 
 For reference, these are:
 - Rollup name: `astria`
-- Network Id: `912559`
+- Network Id: `1337`
 
 This will also take a moment as the rollup node, block explorer, and faucet spin
 up. You can check the progress of the deployment with the following command:

--- a/docs/dev-cluster/3-run-multiple-rollups-locally.md
+++ b/docs/dev-cluster/3-run-multiple-rollups-locally.md
@@ -18,13 +18,13 @@ and network id:
 
 :::warning
 
-**NOTE:** The default rollup name and network id are `astria` and `912559`. When
+**NOTE:** The default rollup name and network id are `astria` and `1337`. When
 deploying your second rollup you _**must**_ use a different name and number.
 
 :::
 
 ```sh
-just deploy-rollup <rollup_name> <network_id>
+just deploy-dev-rollup <rollup_name> <network_id>
 ```
 
 As before, it will take a moment for everything to spin up, but in the meantime


### PR DESCRIPTION
## Description
Updated the documentation for local dev-cluster to use the `deploy-dev-rollup` command since local rollups not dev now suck.

## Motivation and Context
We added light nodes which is ideal for remote deployments, but bad for local rollups. Needed a different command, docs weren't updated.

## Screenshots (if appropriate):
<img width="938" alt="Screenshot 2023-12-04 at 12 04 26 PM" src="https://github.com/astriaorg/docs/assets/459938/6c5a5851-4d36-4f4d-8c30-9eb511c940f2">

## Types of changes
- [x] Edits to existing documentation
- [ ] Changing documentation structure (relocating existing files, ensure redirects exist)
- [ ] Stylistic changes (provide screenshots above)
