### PR TITLE
chore: bump cli version

### DIFF
--- a/docs/components/_astria-cli-install.mdx
+++ b/docs/components/_astria-cli-install.mdx
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="ARM Mac" label="ARM Mac" default>
 
   ```bash
-  curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.2.2/astria-cli-aarch64-apple-darwin.tar.gz > astria-cli.tar.gz
+  curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.3.1/astria-cli-aarch64-apple-darwin.tar.gz > astria-cli.tar.gz
   tar -xvzf astria-cli.tar.gz
   ```
 
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="X86_64 Mac" label="X86_64 Mac">
 
   ```bash
-  curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.2.2/astria-cli-x86_64-apple-darwin.tar.gz > astria-cli.tar.gz
+  curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.3.1/astria-cli-x86_64-apple-darwin.tar.gz > astria-cli.tar.gz
   tar -xvzf astria-cli.tar.gz
   ``` 
 
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="x86_64 Linux" label="x86_64 Linux">
 
   ```bash
-  curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.2.2/astria-cli-x86_64-unknown-linux-gnu.tar.gz > astria-cli.tar.gz
+  curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.3.1/astria-cli-x86_64-unknown-linux-gnu.tar.gz > astria-cli.tar.gz
   tar -xvzf astria-cli.tar.gz
   ```
 
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
    <TabItem value="From Source" label="From Source">
 
   ```bash
-  cargo install astria-cli --git=https://github.com/astriaorg/astria --tag=cli-v0.2.2 --locked
+  cargo install astria-cli --git=https://github.com/astriaorg/astria --tag=cli-v0.3.1 --locked
   ```
 
   </TabItem>


### PR DESCRIPTION
## Description
Updates the version of the CLI

## Motivation and Context
Previous CLI release was incorrect for dusk-3 with a missing default