### PR TITLE
fix: update broken link in docs

### DIFF
--- a/docs/overview/architecture/3-rollup.mdx
+++ b/docs/overview/architecture/3-rollup.mdx
@@ -20,7 +20,7 @@ Read Interface (Rollup to Conductor):
 
 The Composer and Conductor are explained in more detail in future sections.
 
-Both composer and conductor expose [gRPC](https://grpc.io/) interfaces. See the [astria-protos](https://github.com/astriaorg/astria/tree/main/crates/astria-proto) repo for specific implementation details.
+Both composer and conductor expose [gRPC](https://grpc.io/) interfaces. See the [astria-core](https://github.com/astriaorg/astria/tree/main/crates/astria-core) repo for specific implementation details.
 
 Astria currently deploys a fork of
 [Geth](https://github.com/astriaorg/go-ethereum) as an EVM rollup. 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I've found, that link to astria-proto in the docs is not working. Then i discovered that proto has been [renamed](https://github.com/astriaorg/astria/pull/644) to core.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Motivation is to keep docs updated and working.

## Screenshots (if appropriate):
<!-- Provide before and after screen shots -->
Not required

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Edits to existing documentation
- [ ] Changing documentation structure (relocating existing files, ensure redirects exist)
- [ ] Stylistic changes (provide screenshots above)
