### PR TITLE
cleanup some uncessary tasks; add helpful info

### DIFF
--- a/docs/cloud-rollup/digital-ocean.mdx
+++ b/docs/cloud-rollup/digital-ocean.mdx
@@ -9,7 +9,6 @@ a Kubernetes cluster on Digital Ocean which uses the Astria shared sequencer net
 
 ## Local Dependencies
 
-### Install the latest Astria cli
 import RemoteCli from '../components/_cli-cloud.mdx';
 
 <RemoteCli />
@@ -28,6 +27,11 @@ Install and configure `doctl`: [https://docs.digitalocean.com/reference/doctl/ho
 
 Follow the instructions in Digital Ocean's [Quick Start Guide](https://docs.digitalocean.com/products/kubernetes/getting-started/)
 to create a new cluster in the region of your choosing.
+
+:::tip
+The celestia pod has a minimum requirement of 1vCPU and 4GB RAM and will not start if the
+cluster has no nodes that meet those requirements. You will need a node with >1vCPU and >4GB RAM.
+:::
 
 ## Configure `kubectl` with `doctl`
 
@@ -132,7 +136,7 @@ Replace the tags in the commands and env vars below, as follows:
 
 | Var Name | Var Type | Description |
 |-----|-----|-----|
-| `<YOUR_ROLLUP_NAME>` | String | The name of your rollup. This must be alphanumeric, `-` is allowed, this will be included in URLs|
+| `<YOUR_ROLLUP_NAME>` | String | The name of your rollup. This must be alphanumeric, `-` is allowed, this will be included in URLs. Must not be more than 22 characters.|
 | `<YOUR_NETWORK_ID>` | u64 | The id of your network. Pick a > 6 digit number (eg. `123456`) |
 | `<YOUR_HOSTNAME>` | String | The chosen hostname for your network (eg. `astria.org`) |
 

--- a/docs/cloud-rollup/digital-ocean.mdx
+++ b/docs/cloud-rollup/digital-ocean.mdx
@@ -136,7 +136,7 @@ Replace the tags in the commands and env vars below, as follows:
 
 | Var Name | Var Type | Description |
 |-----|-----|-----|
-| `<YOUR_ROLLUP_NAME>` | String | The name of your rollup. This must be alphanumeric, `-` is allowed, this will be included in URLs. Must not be more than 22 characters.|
+| `<YOUR_ROLLUP_NAME>` | String | The name of your rollup. This must be alphanumeric, `-` is allowed, this will be included in URLs. Must not be more than 21 characters.|
 | `<YOUR_NETWORK_ID>` | u64 | The id of your network. Pick a > 6 digit number (eg. `123456`) |
 | `<YOUR_HOSTNAME>` | String | The chosen hostname for your network (eg. `astria.org`) |
 

--- a/docs/components/_astria-cli-install.mdx
+++ b/docs/components/_astria-cli-install.mdx
@@ -1,9 +1,3 @@
-### Clone the Astria [dev-cluster](https://github.com/astriaorg/dev-cluster/tree/main)
-
-```bash
-git clone --branch dusk-3 https://github.com/astriaorg/dev-cluster.git
-```
-
 ### Install the latest [astria cli](https://github.com/astriaorg/astria/releases/tag/cli-v0.2.2)
 
 import Tabs from '@theme/Tabs';
@@ -15,6 +9,7 @@ import TabItem from '@theme/TabItem';
   ```bash
   curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.3.1/astria-cli-aarch64-apple-darwin.tar.gz > astria-cli.tar.gz
   tar -xvzf astria-cli.tar.gz
+  mv astria-cli /usr/local/bin/
   ```
 
   </TabItem>
@@ -23,6 +18,7 @@ import TabItem from '@theme/TabItem';
   ```bash
   curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.3.1/astria-cli-x86_64-apple-darwin.tar.gz > astria-cli.tar.gz
   tar -xvzf astria-cli.tar.gz
+  mv astria-cli /usr/local/bin/
   ``` 
 
   </TabItem>
@@ -31,6 +27,7 @@ import TabItem from '@theme/TabItem';
   ```bash
   curl -L https://github.com/astriaorg/astria/releases/download/cli-v0.3.1/astria-cli-x86_64-unknown-linux-gnu.tar.gz > astria-cli.tar.gz
   tar -xvzf astria-cli.tar.gz
+  mv astria-cli /usr/local/bin/
   ```
 
   </TabItem>

--- a/docs/local-rollup/1-introduction.mdx
+++ b/docs/local-rollup/1-introduction.mdx
@@ -18,7 +18,12 @@ If you would like to deploy a rollup on a remote Kubernetes cluster,
 This guide has been tested on MacOS and Linux but not Windows
 :::
 
-### Install the latest Astria cli
+### Clone the Astria [dev-cluster](https://github.com/astriaorg/dev-cluster/tree/main)
+
+```bash
+git clone --branch dusk-3 https://github.com/astriaorg/dev-cluster.git
+```
+
 import LocalCli from '../components/_cli-local.mdx';
 
 <LocalCli />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Remove unnecessary dev-cluster cloning step from Digital Ocean guide
- Add a step to the astria-cli installation to move the binary into the shell path
- Add a note for required cluster node sizing (for celestia pod)
- Add a note for rollup name length limitations
  - K8s label names are limited to 63 chars. One of the labels concats the rollup name with `-celestia-node-light-mocha-4-token-service` effectively limiting the current max length of a rollup name to 21 chars.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This will help users follow the guide while avoiding pitfalls and errors

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Edits to existing documentation
- [ ] Changing documentation structure (relocating existing files, ensure redirects exist)
- [ ] Stylistic changes (provide screenshots above)
