### PR TITLE
change base to root

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitepress'
-const { BASE: base = "/docs" } = process.env;
+const { BASE: base = "/" } = process.env;
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({


### PR DESCRIPTION
## Description
Changes vitepress base to `/`

## Motivation and Context
Previously, when serving this from gh pages with the default gh pages domain `astriaorg.github.io/docs`, we needed the base to be `/docs` to account for the gh pages path.
Now we are using a custom domain, so the extra base path is no longer needed, and it breaks the css.

## Types of changes
vitepress changes
