### PR TITLE
fix a minor typo in 7-conductor.md

### DIFF
--- a/docs/overview/architecture/7-conductor.md
+++ b/docs/overview/architecture/7-conductor.md
@@ -27,7 +27,7 @@ As mentioned in the
 received by the Conductor directly from the Relayer is considered a soft commit.
 This data is filtered using the rollup's namespace and only transactions that
 are relevant to the rollup are passed on as blocks for execution. These blocks
-are also marked as "safe" withing the rollup. The Conductor regularly polls Celestia for new data
+are also marked as "safe" within the rollup. The Conductor regularly polls Celestia for new data
 and when it sees the same blocks in Celestia that it has already seen from the
 Relayer, it sends a firm commit message to the rollup to update that block to
 "finalized."


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes a minor typo: `withing` -> `within`
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<!-- Provide before and after screen shots -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Edits to existing documentation
- [ ] Changing documentation structure (relocating existing files, ensure redirects exist)
- [ ] Stylistic changes (provide screenshots above)
