### PR TITLE
Add Fork Diff Reference for Flame

### DIFF
--- a/docs/flame/flame-devnet.md
+++ b/docs/flame/flame-devnet.md
@@ -85,3 +85,8 @@ cast send $REC_ADDR --value 10000000000000000000 --private-key <PRIVATE-KEY>
 ```bash
 cast balance $REC_ADDR
 ```
+
+## Fork Diff
+
+Flame is a fork of [go-ethereum](https://github.com/ethereum/go-ethereum). See
+the fork diff [here](https://astriaorg.github.io/astria-geth/).

--- a/docs/flame/flame-testnet.md
+++ b/docs/flame/flame-testnet.md
@@ -87,3 +87,8 @@ cast send $REC_ADDR --value 10000000000000000000 --private-key <PRIVATE-KEY>
 ```bash
 cast balance $REC_ADDR
 ```
+
+## Fork Diff
+
+Flame is a fork of [go-ethereum](https://github.com/ethereum/go-ethereum). See
+the fork diff [here](https://astriaorg.github.io/astria-geth/).


### PR DESCRIPTION
Added a link to the fork diff for Flame from `go-ethereum`.
