### PR TITLE
bump astria-go version to 0.15.1

### DIFF
--- a/docs/components/_astria-go-cli-install.md
+++ b/docs/components/_astria-go-cli-install.md
@@ -3,21 +3,21 @@
 ::: code-group
 
 ```bash [ARM Mac]
-curl -L https://github.com/astriaorg/astria-cli-go/releases/download/v0.15.0/astria-go-v0.15.0-darwin-arm64.tar.gz > astria-cli.tar.gz
+curl -L https://github.com/astriaorg/astria-cli-go/releases/download/v0.15.1/astria-go-v0.15.1-darwin-arm64.tar.gz > astria-cli.tar.gz
 tar -xvzf astria-cli.tar.gz
 mv astria-go /usr/local/bin/
 astria-go version
 ```
 
 ```bash [X86_64 Mac]
-curl -L https://github.com/astriaorg/astria-cli-go/releases/download/v0.15.0/astria-go-v0.15.0-darwin-amd64.tar.gz > astria-cli.tar.gz
+curl -L https://github.com/astriaorg/astria-cli-go/releases/download/v0.15.1/astria-go-v0.15.1-darwin-amd64.tar.gz > astria-cli.tar.gz
 tar -xvzf astria-cli.tar.gz
 mv astria-go /usr/local/bin/
 astria-go version
 ```
 
 ```bash [x86_64 Linux]
-curl -L https://github.com/astriaorg/astria-cli-go/releases/download/v0.15.0/astria-go-v0.15.0-linux-amd64.tar.gz > astria-cli.tar.gz
+curl -L https://github.com/astriaorg/astria-cli-go/releases/download/v0.15.1/astria-go-v0.15.1-linux-amd64.tar.gz > astria-cli.tar.gz
 tar -xvzf astria-cli.tar.gz
 mv astria-go /usr/local/bin/
 astria-go version


### PR DESCRIPTION
## Description

Update astria-go install version from `v0.15.0` to latest release `0.15.1`

## Testing

Manually tested commands
```
curl -L https://github.com/astriaorg/astria-cli-go/releases/download/v0.15.1/astria-go-v0.15.1-darwin-arm64.tar.gz > astria-cli.tar.gz
tar -xvzf astria-cli.tar.gz
mv astria-go /usr/local/bin/
astria-go version
```
confirmed that printed version is `v0.15.1`