### PR TITLE
Update `astria-cli` command docs to match recent changes

### DIFF
--- a/docs/developer/astria-cli/astria-cli-commands.md
+++ b/docs/developer/astria-cli/astria-cli-commands.md
@@ -44,18 +44,19 @@ astria-cli bridge collect-withdrawals [OPTIONS] --rollup-endpoint <ROLLUP_ENDPOI
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--rollup-endpoint <ROLLUP_ENDPOINT>` | The websocket endpoint of a geth compatible rollup |
-| `--contract-address <CONTRACT_ADDRESS>` | The eth address of the astria bridge contracts |
-| `--from-rollup-height <FROM_ROLLUP_HEIGHT>` | The start rollup height from which blocks will be checked for withdrawal events |
-| `--to-rollup-height <TO_ROLLUP_HEIGHT>` | The end rollup height from which blocks will be checked for withdrawal events. If not set, then this tool will stream blocks until SIGINT is received |
-| `--fee-asset <FEE_ASSET>` | The asset that will be used to pay the Sequencer fees (should the generated actions be submitted to the Sequencer) default: ntia |
-| `--sequencer-asset-to-withdraw <SEQUENCER_ASSET_TO_WITHDRAW>` | The sequencer asset withdrawn through the bridge |
-| `--ics20-asset-to-withdraw <ICS20_ASSET_TO_WITHDRAW>` | The is20 asset withdrawn through the bridge |
-| `--bridge-address <BRIDGE_ADDRESS>` | The bech32-encoded bridge address corresponding to the bridged rollup asset on the sequencer. Should match the bridge address in the geth rollup's bridge configuration for that asset |
-| `-o, --output <OUTPUT>` | The path to write the collected withdrawal events converted to Sequencer actions |
-| `-f, --force` | Overwrites "output" if it exists |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--rollup-endpoint <ROLLUP_ENDPOINT>` | string | The websocket endpoint of a geth compatible rollup |
+| `--contract-address <CONTRACT_ADDRESS>` | string | The eth address of the astria bridge contracts |
+| `--from-rollup-height <FROM_ROLLUP_HEIGHT>` | u64 | The start rollup height from which blocks will be checked for withdrawal events |
+| `--to-rollup-height <TO_ROLLUP_HEIGHT>` | u64 | The end rollup height from which blocks will be checked for withdrawal events. If not set, then this tool will stream blocks until SIGINT is received |
+| `--fee-asset <FEE_ASSET>` | string | The asset that will be used to pay the Sequencer fees (should the generated actions be submitted to the Sequencer) default: ntia |
+| `--sequencer-asset-to-withdraw <SEQUENCER_ASSET_TO_WITHDRAW>` | string | The sequencer asset withdrawn through the bridge |
+| `--ics20-asset-to-withdraw <ICS20_ASSET_TO_WITHDRAW>` | string | The is20 asset withdrawn through the bridge |
+| `--bridge-address <BRIDGE_ADDRESS>` | string | The bech32-encoded bridge address corresponding to the bridged rollup asset on the sequencer. Should match the bridge address in the geth rollup's bridge configuration for that asset |
+| `--use-compat-address` | bool | Use Astria compat addresses when withdrawing assets to chains that require bech32 addresses (like for noble USDC). |
+| `-o, --output <OUTPUT>` | string | The path to write the collected withdrawal events converted to Sequencer actions |
+| `-f, --force` | bool | Overwrites "output" if it exists |
 
 ## `bridge submit-withdrawals`
 
@@ -67,13 +68,13 @@ Submit collected withdrawal actions.
 astria-cli bridge submit-withdrawals [OPTIONS] --input <INPUT> --signing-key <SIGNING_KEY> --sequencer-chain-id <SEQUENCER_CHAIN_ID> --sequencer-url <SEQUENCER_URL>
 ```
 
-| Flag | Description |
-|---|---|
-| `-i, --input <INPUT>` | Path to the file containing the actions to submit |
-| `--signing-key <SIGNING_KEY>` | Path to the file containing the signing key |
-| `--sequencer-address-prefix <SEQUENCER_ADDRESS_PREFIX>` | The address prefix for the sequencer account [default: astria] |
-| `--sequencer-chain-id <SEQUENCER_CHAIN_ID>` | The chain ID of the sequencer |
-| `--sequencer-url <SEQUENCER_URL>` | The URL of the sequencer rpc |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `-i, --input <INPUT>` | string | Path to the file containing the actions to submit |
+| `--signing-key <SIGNING_KEY>` | string | Path to the file containing the signing key |
+| `--sequencer-address-prefix <SEQUENCER_ADDRESS_PREFIX>` | string | The address prefix for the sequencer account [default: astria] |
+| `--sequencer-chain-id <SEQUENCER_CHAIN_ID>` | string | The chain ID of the sequencer |
+| `--sequencer-url <SEQUENCER_URL>` | string | The URL of the sequencer rpc |
 
 ## `sequencer account create`
 
@@ -95,9 +96,9 @@ Get the balance of an account on the Astria Sequencer.
 sequencer account balance [OPTIONS] <ADDRESS>
 ```
 
-| Flag | Description |
-|---|---|
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
 
 ## `sequencer account nonce`
 
@@ -109,9 +110,9 @@ Get the nonce of an account on the Astria Sequencer.
 astria-cli sequencer account nonce [OPTIONS] <ADDRESS>
 ```
 
-| Flag | Description |
-|---|---|
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
 
 ## `sequencer address bech32m`
 
@@ -124,10 +125,10 @@ account address.
 astria-cli sequencer address bech32m [OPTIONS] --bytes <BYTES>
 ```
 
-| Flag | Description |
-|---|---|
-| `--bytes <BYTES>` | The hex formatted byte part of the bech32m address |
-| `--prefix <PREFIX>` | The human readable prefix (Hrp) of the bech32m adress [default: astria] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--bytes <BYTES>` | string | The hex formatted byte part of the bech32m address |
+| `--prefix <PREFIX>` | string | The human readable prefix (Hrp) of the bech32m address [default: astria] |
 
 ## `sequencer balance get`
 
@@ -139,9 +140,9 @@ Get the balance of an account on the Astria sequencer.
 astria-cli sequencer balance get
 ```
 
-| Flag | Description |
-|---|---|
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
 
 ## `sequencer blockheight get`
 
@@ -153,10 +154,10 @@ Get the current blockheight of the Astria sequencer.
 astria-cli sequencer blockheight get [OPTIONS]
 ```
 
-| Flag | Description |
-|---|---|
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
 
 ## `sequencer bridge-lock`
 
@@ -170,16 +171,16 @@ astria-cli sequencer bridge-lock [OPTIONS] --amount <AMOUNT> --destination-chain
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--amount <AMOUNT>` | The amount being locked |
-| `--destination-chain-address <DESTINATION_CHAIN_ADDRESS>` | The address on the destination chain |
-| `--prefix <PREFIX>` |  The prefix to construct a bech32m address given the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` |  The private key of the account locking the funds [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` |  The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--asset <ASSET>` |  The asset to lock [default: nria] |
-| `--fee-asset <FEE_ASSET>` | The asset to pay the transfer fees with [default: nria] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--amount <AMOUNT>` | u128 | The amount being locked |
+| `--destination-chain-address <DESTINATION_CHAIN_ADDRESS>` | string | The address on the destination chain |
+| `--prefix <PREFIX>` | string | The prefix to construct a bech32m address given the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the account locking the funds [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--asset <ASSET>` | string | The asset to lock [default: nria] |
+| `--fee-asset <FEE_ASSET>` | string | The asset to pay the transfer fees with [default: nria] |
 
 ## `sequencer init-bridge-account`
 
@@ -193,15 +194,15 @@ astria-cli sequencer init-bridge-account [OPTIONS] --private-key <PRIVATE_KEY> -
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--prefix <PREFIX>` |  The bech32m prefix that will be used for constructing addresses using the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the account initializing the bridge account [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` |  The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` |  The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--rollup-name <ROLLUP_NAME>` |  Plaintext rollup name (to be hashed into a rollup ID) to initialize the bridge account with |
-| `--asset <ASSET>` | The asset to transer [default: nria] |
-| `--fee-asset <FEE_ASSET>` | The asset to pay the transfer fees with [default: nria] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--prefix <PREFIX>` | string | The bech32m prefix that will be used for constructing addresses using the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the account initializing the bridge account [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--rollup-name <ROLLUP_NAME>` | string | Plaintext rollup name (to be hashed into a rollup ID) to initialize the bridge account with |
+| `--asset <ASSET>` | string | The asset to transer [default: nria] |
+| `--fee-asset <FEE_ASSET>` | string | The asset to pay the transfer fees with [default: nria] |
 
 ## `sequencer sudo ibc-relayer add`
 
@@ -215,13 +216,13 @@ astria-cli sequencer sudo ibc-relayer add [OPTIONS] --private-key <PRIVATE_KEY> 
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--prefix <PREFIX>` | The prefix to construct a bech32m address given the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the account authorizing the change [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--address <ADDRESS>` | The address to add or remove as an IBC relayer |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--prefix <PREFIX>` | string | The prefix to construct a bech32m address given the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the account authorizing the change [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--address <ADDRESS>` | string | The address to add or remove as an IBC relayer |
 
 ## `sequencer sudo ibc-relayer remove`
 
@@ -233,13 +234,13 @@ Remove an IBC-relayer address from the list of relayers on the Astria sequencer.
 astria-cli sequencer sudo ibc-relayer remove [OPTIONS] --private-key <PRIVATE_KEY> --address <ADDRESS>
 ```
 
-| Flag | Description |
-|---|---|
-| `--prefix <PREFIX>` | The prefix to construct a bech32m address given the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the account authorizing the change [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--address <ADDRESS>` | The address to add or remove as an IBC relayer |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--prefix <PREFIX>` | string | The prefix to construct a bech32m address given the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the account authorizing the change [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--address <ADDRESS>` | string | The address to add or remove as an IBC relayer |
 
 ## `sequencer sudo fee-asset add`
 
@@ -252,13 +253,13 @@ Astria sequencer.
 astria-cli sequencer sudo fee-asset add [OPTIONS] --private-key <PRIVATE_KEY> --asset <ASSET>
 ```
 
-| Flag | Description |
-|---|---|
-| `--prefix <PREFIX>` | The prefix to construct a bech32m address given the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--address <ADDRESS>` | The address to add or remove as an IBC relayer |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--prefix <PREFIX>` | string | The prefix to construct a bech32m address given the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--address <ADDRESS>` | string | The address to add or remove as an IBC relayer |
 
 ## `sequencer sudo fee-asset remove`
 
@@ -271,13 +272,13 @@ Astria sequencer.
 astria-cli sequencer sudo fee-asset remove [OPTIONS] --private-key <PRIVATE_KEY> --asset <ASSET>
 ```
 
-| Flag | Description |
-|---|---|
-| `--prefix <PREFIX>` | The prefix to construct a bech32m address given the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--address <ADDRESS>` | The address to add or remove as an IBC relayer |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--prefix <PREFIX>` | string | The prefix to construct a bech32m address given the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--address <ADDRESS>` | string | The address to add or remove as an IBC relayer |
 
 ## `sequencer sudo sudo-address-change`
 
@@ -289,13 +290,13 @@ Update the sudo address for the Astria sequencer.
 astria-cli sequencer sudo sudo-address-change [OPTIONS] --private-key <PRIVATE_KEY> --address <ADDRESS>
 ```
 
-| Flag | Description |
-|---|---|
-| `--prefix <PREFIX>` | The prefix to construct a bech32m address given the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--address <ADDRESS>` | The address to add or remove as an IBC relayer |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--prefix <PREFIX>` | string | The prefix to construct a bech32m address given the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--address <ADDRESS>` | string | The address to add or remove as an IBC relayer |
 
 ## `sequencer sudo validator-update`
 
@@ -307,14 +308,14 @@ Update a validators power on the Astria sequencer.
 astria-cli sequencer sudo validator-update [OPTIONS] --private-key <PRIVATE_KEY> --validator-public-key <VALIDATOR_PUBLIC_KEY> --power <POWER>
 ```
 
-| Flag | Description |
-|---|---|
-| `--sequencer-url <SEQUENCER_URL>`  |  The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--prefix <PREFIX>` | The bech32m prefix that will be used for constructing addresses using the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
-| `--validator-public-key <VALIDATOR_PUBLIC_KEY>` | The address of the Validator being updated |
-| `--power <POWER>` | The power the validator is being updated to |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--prefix <PREFIX>` | string | The bech32m prefix that will be used for constructing addresses using the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the sudo account authorizing change [env: SEQUENCER_PRIVATE_KEY=] |
+| `--validator-public-key <VALIDATOR_PUBLIC_KEY>` | string | The address of the Validator being updated |
+| `--power <POWER>` | string | The power the validator is being updated to |
 
 ## `sequencer transfer`
 
@@ -326,15 +327,15 @@ Send a transfer between accounts on the Astria sequencer.
 astria-cli sequencer transfer [OPTIONS] --amount <AMOUNT> --private-key <PRIVATE_KEY> <TO_ADDRESS>
 ```
 
-| Flag | Description |
-|---|---|
-| `--amount <AMOUNT>` |  The amount being sent |
-| `--prefix <PREFIX>` | The bech32m prefix that will be used for constructing addresses using the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of account being sent from [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--asset <ASSET>` | The asset to transer [default: ntia] |
-| `--fee-asset <FEE_ASSET>` | The asset to pay the transfer fees with [default: ntia] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--amount <AMOUNT>` | u128 | The amount being sent |
+| `--prefix <PREFIX>` | string | The bech32m prefix that will be used for constructing addresses using the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of account being sent from [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--asset <ASSET>` | string | The asset to transer [default: ntia] |
+| `--fee-asset <FEE_ASSET>` | string | The asset to pay the transfer fees with [default: ntia] |
 
 ## `sequencer threshold dkg`
 
@@ -348,14 +349,14 @@ astria-cli sequencer threshold dkg [OPTIONS] --index <INDEX> --min-signers <MIN_
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--index <INDEX>` | Index of the participant of the DKG protocol. must be 1 <= index <= n, where n is the maximum number of signers |
-| `--min-signers <MIN_SIGNERS>` | Minimum number of signers required to sign a transaction |
-| `--max-signers <MAX_SIGNERS>` | Maximum number of signers that can sign a transaction |
-| `--secret-key-package-path <SECRET_KEY_PACKAGE_PATH>` | Path to a file with the output secret key package from keygen ceremony |
-| `--public-key-package-path <PUBLIC_KEY_PACKAGE_PATH>` | Path to a file with the output public key package from keygen ceremony |
-| `--prefix <PREFIX>` | The address prefix for the generated address [default: astria] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--index <INDEX>` | u16 | Index of the participant of the DKG protocol. must be 1 <= index <= n, where n is the maximum number of signers |
+| `--min-signers <MIN_SIGNERS>` | u16 | Minimum number of signers required to sign a transaction |
+| `--max-signers <MAX_SIGNERS>` | u16 | Maximum number of signers that can sign a transaction |
+| `--secret-key-package-path <SECRET_KEY_PACKAGE_PATH>` | string | Path to a file with the output secret key package from keygen ceremony |
+| `--public-key-package-path <PUBLIC_KEY_PACKAGE_PATH>` | string | Path to a file with the output public key package from keygen ceremony |
+| `--prefix <PREFIX>` | string | The address prefix for the generated address [default: astria] |
 
 ## `sequencer threshold sign part1`
 
@@ -369,10 +370,10 @@ astria-cli sequencer threshold sign part1 --secret-key-package-path <SECRET_KEY_
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--secret-key-package-path <SECRET_KEY_PACKAGE_PATH>` | Path to a file with the secret key package from keygen ceremony |
-| `--nonces-path <NONCES_PATH>` | Path to a file to output the nonces |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--secret-key-package-path <SECRET_KEY_PACKAGE_PATH>` | string | Path to a file with the secret key package from keygen ceremony |
+| `--nonces-path <NONCES_PATH>` | string | Path to a file to output the nonces |
 
 ## `sequencer threshold sign prepare-message`
 
@@ -387,11 +388,11 @@ astria-cli sequencer threshold sign prepare-message [OPTIONS] --message-path <ME
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--message-path <MESSAGE_PATH>` | Path to file with message (json-formatted `TransactionBody`) to be signed |
-| `--plaintext` | If set, the message is treated as plaintext and signed as-is, without re-encoding into protobuf bytes |
-| `--signing-package-path <SIGNING_PACKAGE_PATH>` | Path to the signing package output file |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--message-path <MESSAGE_PATH>` | string | Path to file with message (json-formatted `TransactionBody`) to be signed |
+| `--plaintext` | bool | If set, the message is treated as plaintext and signed as-is, without re-encoding into protobuf bytes |
+| `--signing-package-path <SIGNING_PACKAGE_PATH>` | string | Path to the signing package output file |
 
 ## `sequencer threshold sign part2`
 
@@ -405,11 +406,11 @@ astria-cli sequencer threshold sign part2 --secret-key-package-path <SECRET_KEY_
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--secret-key-package-path <SECRET_KEY_PACKAGE_PATH>` | Path to a file with the secret key package from keygen ceremony |
-| `--nonces-path <NONCES_PATH>` | Path to nonces file from part 1 |
-| `--signing-package-path <SIGNING_PACKAGE_PATH>` | Path to the signing package |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--secret-key-package-path <SECRET_KEY_PACKAGE_PATH>` | string | Path to a file with the secret key package from keygen ceremony |
+| `--nonces-path <NONCES_PATH>` | string | Path to nonces file from part 1 |
+| `--signing-package-path <SIGNING_PACKAGE_PATH>` | string | Path to the signing package |
 
 ## `sequencer threshold sign aggregate`
 
@@ -423,13 +424,13 @@ astria-cli sequencer threshold sign aggregate [OPTIONS] --signing-package-path <
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--signing-package-path <SIGNING_PACKAGE_PATH>` | Path to the signing package |
-| `--public-key-package-path <PUBLIC_KEY_PACKAGE_PATH>` | Path to a file with the public key package from keygen ceremony |
-| `--message-path <MESSAGE_PATH>` | Optionally, path to the message bytes that were signed |
-| `--output-path <OUTPUT_PATH>` | Optionally, path to output the signed message as a sequencer transaction |
-| `--plaintext` | Whether the message is plaintext (not a `TransactionBody`) |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--signing-package-path <SIGNING_PACKAGE_PATH>` | string | Path to the signing package |
+| `--public-key-package-path <PUBLIC_KEY_PACKAGE_PATH>` | string | Path to a file with the public key package from keygen ceremony |
+| `--message-path <MESSAGE_PATH>` | string | Optionally, path to the message bytes that were signed |
+| `--output-path <OUTPUT_PATH>` | string | Optionally, path to output the signed message as a sequencer transaction |
+| `--plaintext` | bool | Whether the message is plaintext (not a `TransactionBody`) |
 
 ## `sequencer threshold verify`
 
@@ -443,12 +444,12 @@ astria-cli sequencer threshold verify [OPTIONS] --verifying-key <VERIFYING_KEY> 
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--verifying-key <VERIFYING_KEY>` | Hex-encoded verifying key |
-| `--message-path <MESSAGE_PATH>` | Path to file with message bytes to verify |
-| `--signature <SIGNATURE>` | Hex-encoded signature |
-| `--plaintext` | Set if the incoming message is plaintext, otherwise it is assumed to be `TransactionBody` in pbjson format |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--verifying-key <VERIFYING_KEY>` | string | Hex-encoded verifying key |
+| `--message-path <MESSAGE_PATH>` | string | Path to file with message bytes to verify |
+| `--signature <SIGNATURE>` | string | Hex-encoded signature |
+| `--plaintext` | bool | Set if the incoming message is plaintext, otherwise it is assumed to be `TransactionBody` in pbjson format |
 
 ## `sequencer ics20-withdrawal`
 
@@ -462,21 +463,21 @@ astria-cli sequencer ics20-withdrawal [OPTIONS] --amount <AMOUNT> --destination-
 
 ### Flags
 
-| Flag | Description |
-|---|---|
-| `--amount <AMOUNT>` | The transfer amount to send |
-| `--destination-chain-address <DESTINATION_CHAIN_ADDRESS>` | The address on the destination chain |
-| `--source-channel <SOURCE_CHANNEL>` | The source channel used for withdrawal |
-| `--return-address <RETURN_ADDRESS>` | The address to refund on timeout, if unset refunds the signer |
-| `--memo <MEMO>` | An optional memo to send with transaction |
-| `--bridge-address <BRIDGE_ADDRESS>` | The bridge account to transfer from |
-| `--compat` | Use compatibility address format (for example: when sending USDC to Noble) |
-| `--prefix <PREFIX>`| The prefix to construct a bech32m address given the private key [default: astria] |
-| `--private-key <PRIVATE_KEY>` | The private key of the account withdrawing the funds [env: SEQUENCER_PRIVATE_KEY=] |
-| `--sequencer-url <SEQUENCER_URL>` | The url of the Sequencer node [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
-| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] [default: astria-dusk-11] |
-| `--asset <ASSET>` | The asset to withdraw [default: nria] |
-| `--fee-asset <FEE_ASSET>` | The asset to be used to pay the fees [default: nria] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `--amount <AMOUNT>` | u128 | The transfer amount to send |
+| `--destination-chain-address <DESTINATION_CHAIN_ADDRESS>` | string | The address on the destination chain |
+| `--source-channel <SOURCE_CHANNEL>` | string | The source channel used for withdrawal |
+| `--return-address <RETURN_ADDRESS>` | string | The address to refund on timeout, if unset refunds the signer |
+| `--memo <MEMO>` | string | An optional memo to send with transaction |
+| `--bridge-address <BRIDGE_ADDRESS>` | string | The bridge account to transfer from |
+| `--compat` | bool | Use compatibility address format (for example: when sending USDC to Noble) |
+| `--prefix <PREFIX>`| string | The prefix to construct a bech32m address given the private key [default: astria] |
+| `--private-key <PRIVATE_KEY>` | string | The private key of the account withdrawing the funds [env: SEQUENCER_PRIVATE_KEY=] |
+| `--sequencer-url <SEQUENCER_URL>` | string | The url of the Sequencer node [env: SEQUENCER_URL=] |
+| `--sequencer.chain-id <SEQUENCER_CHAIN_ID>` | string | The chain id of the sequencing chain being used [env: ROLLUP_SEQUENCER_CHAIN_ID=] |
+| `--asset <ASSET>` | string | The asset to withdraw [default: nria] |
+| `--fee-asset <FEE_ASSET>` | string | The asset to be used to pay the fees [default: nria] |
 
 ## `sequencer submit`
 
@@ -490,10 +491,10 @@ astria-cli sequencer submit [OPTIONS] <INPUT>
 
 ### Flags and Inputs
 
-| Input | Description |
-|---|---|
-| `<INPUT>` | The source to read the pbjson formatted astra.protocol.transaction.v1.Transaction (use `-` to pass via STDIN) |
-| `--sequencer-url <SEQUENCER_URL>` | The URL at which the Sequencer node is listening for ABCI commands [env: SEQUENCER_URL=] [default: https://rpc.sequencer.dusk-11.devnet.astria.org] |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `<INPUT>` | string | The source to read the pbjson formatted astra.protocol.transaction.v1.Transaction (use `-` to pass via STDIN) |
+| `--sequencer-url <SEQUENCER_URL>` | string | The URL at which the Sequencer node is listening for ABCI commands [env: SEQUENCER_URL=] |
 
 ## `sequencer sign`
 
@@ -507,9 +508,9 @@ astria-cli sequencer sign [OPTIONS] --private-key <PRIVATE_KEY> <INPUT>
 
 ### Flags and Inputs
 
-| Input | Description |
-|---|---|
-| `<INPUT>` | The source to read the pbjson formatted astra.protocol.transaction.v1.Transaction (use `-` to pass via STDIN) |
-| `--private-key <PRIVATE_KEY>` | The private key of account being sent from [env: SEQUENCER_PRIVATE_KEY=] |
-| `-o`, `--output <OUTPUT>` | Target to write the signed transaction in pbjson format (omit to write to STDOUT) |
-| `-f`, `--force` | Forces an overwrite of `--output` if a file at that location exists |
+| Flag | Arg Type | Description |
+|---|---|---|
+| `<INPUT>` | string | The source to read the pbjson formatted astra.protocol.transaction.v1.Transaction (use `-` to pass via STDIN) |
+| `--private-key <PRIVATE_KEY>` | string | The private key of account being sent from [env: SEQUENCER_PRIVATE_KEY=] |
+| `-o`, `--output <OUTPUT>` | string | Target to write the signed transaction in pbjson format (omit to write to STDOUT) |
+| `-f`, `--force` | bool | Forces an overwrite of `--output` if a file at that location exists |


### PR DESCRIPTION
Update the `astria-cli` command reference docs to reflect recently merged prs.
Also changed the flag and argument tables to match the format of the go cli.