### PR TITLE
chore: noVM-messenger genesis configuration

### DIFF
--- a/docs/tutorials/novm-messenger-rollup.md
+++ b/docs/tutorials/novm-messenger-rollup.md
@@ -81,23 +81,46 @@ local_path = '<your local path to>/noVM-messenger/target/debug/chat-rollup'
 args = []
 ```
 
+Then add a new rollup genesis file to `<absolute path of your home dir>/.astria/novm/config/rollup_genesis.json`.
+you will need to update manually the `rollup_name`:
+
+```json
+// rollup_genesis.json
+{
+    "rollup_name": "chat-rollup",
+    "accounts": [
+        {
+            "address": {
+                "bech32m": "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
+            },
+            "balance": {
+                "lo": 100000000000000000
+            }
+        }
+    ],
+    "sequencer_genesis_block_height": 2,
+    "celestia_genesis_block_height": 2,
+    "celestia_block_variance": 100,
+    "authority_sudo_address": {
+        "bech32m": "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
+    }
+}
+```
+
 Then open `~/.astria/novm/config/base-config.toml` and add the following to that
-file. You will need to manually update the `db_filepath`:
+file. You will need to manually update the `db_filepath` and `genesis_filepath`:
 
 ```toml {4}
 metrics_http_listener_addr = 'http://127.0.0.1:50053'
 log = 'debug'
 composer_addr = 'http://127.0.0.1:50052'
 db_filepath = '<absolute path of your home dir>/.astria/novm/data/rollup_data'
+genesis_filepath = '<absolute path of your home dir>/.astria/novm/config/rollup_genesis.json'
 execution_grpc_addr = '0.0.0.0:50051'
 force_stdout = 'true'
 pretty_print = 'true'
 no_otel = 'true'
 no_metrics = 'true'
-rollup_name = 'astria-chat'
-sequencer_genesis_block_height = '0'
-celestia_genesis_block_height = '0'
-celestia_block_variance = '100'
 ```
 
 You will also need to update the `astria_composer_grpc_addr` already present in

--- a/docs/tutorials/novm-messenger-rollup.md
+++ b/docs/tutorials/novm-messenger-rollup.md
@@ -82,7 +82,7 @@ args = []
 ```
 
 Then add a new rollup genesis file to `<absolute path of your home dir>/.astria/novm/config/rollup_genesis.json`.
-you will need to update manually the `rollup_name`:
+you will need to manually update the `rollup_name`:
 
 ```json
 // rollup_genesis.json
@@ -106,6 +106,9 @@ you will need to update manually the `rollup_name`:
     }
 }
 ```
+
+To add another genesis account, use the astria-go CLI to generate
+an address and append it to the account field.
 
 Then open `~/.astria/novm/config/base-config.toml` and add the following to that
 file. You will need to manually update the `db_filepath` and `genesis_filepath`:


### PR DESCRIPTION
## Description
The noVM-messenger rollup is moving to using a `genesis.json` in https://github.com/astriaorg/noVM-messenger/pull/16, therefor the relevant docs need additional configuration instructions. This PR gives an example `genesis.json` file and instructions on how to add it.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Edits to existing documentation
- [ ] Changing documentation structure (relocating existing files, ensure redirects exist)
- [ ] Stylistic changes (provide screenshots above)

