### PR TITLE
Add `novm` tutorial for using charts to deploy

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -171,6 +171,7 @@ function sidebar() {
         {text: 'Run a Local Rollup and Sequencer', link: '/tutorials/run-local-rollup-and-sequencer.md' },
         {text: 'Run a Local Rollup against a Remote Sequencer', link: '/tutorials/run-local-rollup-against-remote-sequencer.md' },
         {text: 'Run a noVM-messenger Rollup', link: '/tutorials/novm-messenger-rollup.md' },
+        {text: 'Deploy a noVM-messenger Rollup with Charts', link: '/tutorials/deploy-novm-messenger-with-charts.md' },
         {text: 'Test Transactions', link: '/tutorials/test-transactions.md' }
       ]
     },

--- a/docs/components/_clone-build-deploy-novm-messenger.md
+++ b/docs/components/_clone-build-deploy-novm-messenger.md
@@ -1,0 +1,22 @@
+<!-- markdownlint-disable MD041 MD013 -->
+
+::: code-group
+
+```bash [SSH]
+git clone git@github.com:astriaorg/noVM-messenger.git
+cd noVM-messenger
+just deploy-astria-chat
+```
+
+```bash [HTTP]
+git clone https://github.com/astriaorg/noVM-messenger.git
+cd noVM-messenger
+just deploy-astria-chat
+```
+
+:::
+
+<!-- <Tabs>
+  <TabItem value="SSH" label="SSH"> </TabItem>
+  <TabItem value="HTTP" label="HTTP"> </TabItem>
+</Tabs> -->

--- a/docs/tutorials/deploy-novm-messenger-with-charts.md
+++ b/docs/tutorials/deploy-novm-messenger-with-charts.md
@@ -1,0 +1,46 @@
+# Deploy a `noVM` Messenger Rollup using the Astria Deployment Charts
+
+The primary difference between this tutorial and the [Run a noVM-messenger
+Rollup](./novm-messenger-rollup.md) tutorial is that we are shifting from a
+rapid development workflow using the [astria-go
+cli](../developer/astria-go/astria-go-installation.md) with minimal dependencies
+and a subset of all software required for running in production, to
+containerizing the software for a more realistic production simulation. While
+the previous guide emphasized quick, iterative development with fewer
+components, this version incorporates additional software dependencies to better
+mimic a production environment while utilizing those tools to simplify the
+deployment process with significantly fewer commands.
+
+## Dependencies
+
+Running the Deployment Charts requires the following dependencies:
+
+- [docker](https://docs.docker.com/get-docker/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [helm](https://helm.sh/docs/intro/install/)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [just](https://just.systems/man/en/chapter_4.html)
+
+## Clone, Build, and Run the noVM Chat Rollup
+
+Make sure that the Docker daemon is running, then run the following commands:
+
+<!--@include: ../components/_clone-build-deploy-novm-messenger.md-->
+
+Then open
+[http://chat.astria-chat.localdev.me/](http://chat.astria-chat.localdev.me/) in
+your browser to use the UI and send messages.
+
+::: info
+The deployment should take less than 5 minutes, but this will depend on the
+speed of your machine and/or download times for images.
+:::
+
+
+## Cleanup
+
+When you want to stop the local cluster you can run the following:
+
+```bash
+just delete-all
+```

--- a/docs/tutorials/deploy-novm-messenger-with-charts.md
+++ b/docs/tutorials/deploy-novm-messenger-with-charts.md
@@ -36,7 +36,6 @@ The deployment should take less than 5 minutes, but this will depend on the
 speed of your machine and/or download times for images.
 :::
 
-
 ## Cleanup
 
 When you want to stop the local cluster you can run the following:


### PR DESCRIPTION
Add a tutorial for deploying the `noVM-messenger` rollup using deployment charts.

This pr requires that https://github.com/astriaorg/noVM-messenger/pull/27 is merged.
